### PR TITLE
fix(mathquill): implement jQuery two-arg toggleClass in ESM shimMathQ…

### DIFF
--- a/src/jquery-shim.js
+++ b/src/jquery-shim.js
@@ -37,11 +37,19 @@ DOMCollection.prototype.removeClass = function(className) {
   return this;
 };
 
-DOMCollection.prototype.toggleClass = function(className) {
+// jQuery: .toggleClass(name) flips; .toggleClass(name, state) forces on/off.
+// MathQuill relies on the two-arg form in Letter.italicize (mq-operator-name)
+// and elsewhere; ignoring `state` broke operator vs variable styling (ESM build).
+DOMCollection.prototype.toggleClass = function(className, state) {
   var classes = (className || '').split(/\s+/).filter(Boolean);
+  var force = arguments.length > 1 ? !!state : null;
   this.elements.forEach(function(el) {
     classes.forEach(function(c) {
-      el.classList.toggle(c);
+      if (force === null) {
+        el.classList.toggle(c);
+      } else {
+        el.classList.toggle(c, force);
+      }
     });
   });
   return this;


### PR DESCRIPTION
…uill calls toggleClass(name, state) to add/remove mq-operator-name inLetter.italicize; the shim only flipped classes and ignored state, which brokeoperator vs variable styling and live typing. Delegate to classList.toggle(token, force)when a second argument is present.