### PR TITLE
fix(mathquill): support array argument in shim .add (Fragment DOM)Mat…

### DIFF
--- a/src/jquery-shim.js
+++ b/src/jquery-shim.js
@@ -457,6 +457,11 @@ DOMCollection.prototype.add = function(other) {
   var combined = this.elements.slice();
   if (other instanceof DOMCollection) {
     combined.push.apply(combined, other.elements);
+  } else if (Array.isArray(other)) {
+    // Fragment() accumulates raw elements then does this.jQ.add(accum); jQuery accepts
+    // an array of nodes. Without this branch, LiveFraction (/) never moves the wrapped
+    // operand into the numerator in the DOM.
+    combined.push.apply(combined, other);
   } else if (other && other.nodeType) {
     combined.push(other);
   }


### PR DESCRIPTION
…hQuill builds a plain array of nodes then calls this.jQ.add(accum) inFragment’s constructor; jQuery merges those elements, but the ESM shim onlyhandled DOMCollection or a single node, so Fragment.jQ stayed empty andreplacedFragment.jQ.appendTo() no-op’d. Restores LiveFraction (/) wrappingthe left operand into the numerator PD-16.

https://illuminate.atlassian.net/browse/PIE-16